### PR TITLE
Add SMS result sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# Gifted-Open-Mind-Assesment
+# Gifted Open Mind Assessment
+
+A React-based assessment app.
+
+## SMS Results
+
+After completing the assessment, you can send your results via SMS to **1-701-941-0811**. The app will request permission and open your messaging app with the results and a confirmation message ready to send.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Brain, Share2, Printer, RefreshCw, ChevronDown, ChevronUp, Sparkles, BarChart3, TrendingUp, Zap } from 'lucide-react';
+import { Brain, Share2, Printer, RefreshCw, ChevronDown, ChevronUp, Sparkles, BarChart3, TrendingUp, Zap, Send } from 'lucide-react';
 
 // Safe storage wrapper
 const storage = {
@@ -487,7 +487,7 @@ function ScoreCard({ title, score, band, color, icon }) {
 }
 
 // Results Component
-function ResultsView({ result, onRetake, onShare, onPrint, showCopied }) {
+function ResultsView({ result, onRetake, onShare, onPrint, showCopied, onSMS }) {
   const [showDetails, setShowDetails] = useState(false);
   const { scores } = result;
   const narrative = buildNarrative(scores);
@@ -564,6 +564,13 @@ function ResultsView({ result, onRetake, onShare, onPrint, showCopied }) {
             >
               <Share2 className="w-5 h-5" />
               {showCopied ? 'Copied!' : 'Share'}
+            </button>
+            <button
+              onClick={onSMS}
+              className="px-6 py-3 bg-gray-200 text-gray-700 rounded-xl font-semibold hover:bg-gray-300 transition-colors flex items-center gap-2"
+            >
+              <Send className="w-5 h-5" />
+              SMS Results
             </button>
             <button
               onClick={onPrint}
@@ -730,6 +737,23 @@ export default function GiftedOpenMindAssessment() {
     }
   }
 
+  function sendResultViaSMS() {
+    if (!savedResult) return;
+    const token = encodeResult(savedResult);
+
+    if (typeof window !== 'undefined') {
+      const allow = window.confirm('Allow sending SMS messages to 1-701-941-0811?');
+      if (!allow) return;
+
+      const resultMsg = `Assessment results: ${token}`;
+      const consentMsg = 'I agree to send and receive SMS permissions for the assessment.';
+      window.open(`sms:+17019410811?body=${encodeURIComponent(resultMsg)}`);
+      setTimeout(() => {
+        window.open(`sms:+17019410811?body=${encodeURIComponent(consentMsg)}`);
+      }, 500);
+    }
+  }
+
   function printResult() {
     if (typeof window !== 'undefined') {
       window.print();
@@ -886,12 +910,13 @@ export default function GiftedOpenMindAssessment() {
 
   if (currentStep === 'results' && savedResult) {
     return (
-      <ResultsView 
-        result={savedResult} 
-        onRetake={reset} 
-        onShare={shareResult} 
+      <ResultsView
+        result={savedResult}
+        onRetake={reset}
+        onShare={shareResult}
         onPrint={printResult}
         showCopied={copiedToken}
+        onSMS={sendResultViaSMS}
       />
     );
   }


### PR DESCRIPTION
## Summary
- add button to send assessment results via SMS after user permission
- implement SMS workflow that sends both results and consent message to 1-701-941-0811
- document SMS result sharing in README and ignore build artifacts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689883f9c474832a96b2d459ebe31496